### PR TITLE
feat: pin dependencies from uv.lock during PyPI release

### DIFF
--- a/.github/workflows/release.py
+++ b/.github/workflows/release.py
@@ -419,6 +419,127 @@ def cli():
     pass
 
 
+@cli.command('pin-dependencies')
+@click.option('--directory', type=click.Path(exists=True, path_type=Path), default=Path.cwd())
+def pin_dependencies(directory: Path) -> int:
+    """Pin all dependencies in pyproject.toml to exact versions from uv.lock.
+
+    Reads the uv.lock file in the given directory and rewrites every dependency
+    in pyproject.toml to use == (exact) version pins matching the locked
+    resolution. This ensures that packages published to PyPI install the same
+    dependency versions that were tested during development.
+
+    Only registry (PyPI) packages are pinned; editable/local/path sources are
+    skipped. Extras on dependency specifiers (e.g. mcp[cli]) are preserved.
+    """
+    try:
+        validated_directory = validate_path_security(directory)
+        pyproject_path = validated_directory / 'pyproject.toml'
+        lock_path = validated_directory / 'uv.lock'
+
+        if not pyproject_path.exists():
+            raise ValueError(f'pyproject.toml not found in {validated_directory}')
+        if not lock_path.exists():
+            raise ValueError(f'uv.lock not found in {validated_directory}')
+
+        # Parse uv.lock to build {normalized_name: version} mapping
+        lock_content = secure_file_read(lock_path)
+        try:
+            import tomllib
+        except ModuleNotFoundError:
+            import tomli as tomllib  # Python < 3.11
+        lock_data = tomllib.loads(lock_content)
+        locked_versions: dict[str, str] = {}
+        for pkg in lock_data.get('package', []):
+            source = pkg.get('source', {})
+            # Only pin registry packages (from PyPI), skip editable/local/path
+            if 'editable' in source or 'directory' in source or 'path' in source:
+                continue
+            name = pkg.get('name', '')
+            version = pkg.get('version', '')
+            if name and version:
+                locked_versions[_normalize_name(name)] = version
+
+        logging.info(f'Loaded {len(locked_versions)} locked package versions from uv.lock')
+
+        # Read and rewrite pyproject.toml
+        pyproject_content = secure_file_read(pyproject_path)
+        data = tomlkit.parse(pyproject_content)
+        project_section = data.get('project')
+        if not project_section:
+            raise ValueError('No project section in pyproject.toml')
+
+        dependencies = project_section.get('dependencies')
+        if not dependencies:
+            click.echo('No dependencies found in pyproject.toml, nothing to pin')
+            return 0
+
+        pinned_count = 0
+        for i, dep_str in enumerate(dependencies):
+            pinned = _pin_dependency(str(dep_str), locked_versions)
+            if pinned != str(dep_str):
+                dependencies[i] = pinned
+                pinned_count += 1
+                logging.info(f'Pinned: {dep_str} -> {pinned}')
+
+        if pinned_count == 0:
+            click.echo('All dependencies already pinned, no changes needed')
+            return 0
+
+        updated_content = tomlkit.dumps(data)
+        secure_file_write(pyproject_path, updated_content)
+        click.echo(f'Pinned {pinned_count} dependencies in {pyproject_path}')
+        return 0
+
+    except Exception as e:
+        logging.error(f'Pin dependencies failed: {e}')
+        click.echo(f'Error: {e}', err=True)
+        return 1
+
+
+def _normalize_name(name: str) -> str:
+    """Normalize a Python package name for comparison (PEP 503)."""
+    return re.sub(r'[-_.]+', '-', name).lower()
+
+
+def _pin_dependency(dep_str: str, locked_versions: dict[str, str]) -> str:
+    """Rewrite a dependency string to use == with the locked version.
+
+    Handles dependency specifiers like:
+      - "boto3>=1.40.5"        -> "boto3==1.42.62"
+      - "mcp[cli]>=1.23.0"    -> "mcp[cli]==1.26.0"
+      - "loguru==0.7.3"       -> "loguru==0.7.3" (unchanged)
+      - "pkg ; python_version<'3.11'" -> preserves markers
+    """
+    # Split off environment markers (e.g. "; python_version < '3.11'")
+    marker_sep = ';'
+    marker_part = ''
+    base = dep_str
+    if marker_sep in dep_str:
+        base, marker_part = dep_str.split(marker_sep, 1)
+        marker_part = marker_sep + marker_part
+
+    # Extract extras (e.g. [cli]) and package name
+    extras = ''
+    name_part = base.strip()
+    if '[' in name_part:
+        bracket_start = name_part.index('[')
+        bracket_end = name_part.index(']') + 1
+        extras = name_part[bracket_start:bracket_end]
+        name_part = name_part[:bracket_start] + name_part[bracket_end:]
+
+    # Extract just the package name (strip version specifiers)
+    pkg_name = re.split(r'[><=!~]', name_part.strip())[0].strip()
+    normalized = _normalize_name(pkg_name)
+
+    if normalized not in locked_versions:
+        logging.warning(f'No locked version found for {pkg_name}, keeping as-is')
+        return dep_str
+
+    locked_version = locked_versions[normalized]
+    return f'{pkg_name}{extras}=={locked_version}{marker_part}'
+
+
 @cli.command('bump-package')
 @click.option('--directory', type=click.Path(exists=True, path_type=Path), default=Path.cwd())
 def bump_package(directory: Path) -> int:

--- a/.github/workflows/release.py
+++ b/.github/workflows/release.py
@@ -422,12 +422,16 @@ def cli():
 @cli.command('pin-dependencies')
 @click.option('--directory', type=click.Path(exists=True, path_type=Path), default=Path.cwd())
 def pin_dependencies(directory: Path) -> int:
-    """Pin all dependencies in pyproject.toml to exact versions from uv.lock.
+    """Pin ALL dependencies (direct + transitive) to exact versions from uv.lock.
 
-    Reads the uv.lock file in the given directory and rewrites every dependency
-    in pyproject.toml to use == (exact) version pins matching the locked
-    resolution. This ensures that packages published to PyPI install the same
-    dependency versions that were tested during development.
+    Reads the uv.lock file in the given directory and:
+    1. Rewrites existing dependencies in pyproject.toml to use == (exact) pins
+    2. Adds all remaining transitive dependencies from uv.lock as new entries
+
+    This ensures that packages published to PyPI install the exact same
+    dependency tree that was tested during development — including every
+    transitive dependency. This is appropriate for tool packages (MCP servers,
+    CLIs) that run in isolated environments via uvx/pipx.
 
     Only registry (PyPI) packages are pinned; editable/local/path sources are
     skipped. Extras on dependency specifiers (e.g. mcp[cli]) are preserved.
@@ -442,14 +446,14 @@ def pin_dependencies(directory: Path) -> int:
         if not lock_path.exists():
             raise ValueError(f'uv.lock not found in {validated_directory}')
 
-        # Parse uv.lock to build {normalized_name: version} mapping
+        # Parse uv.lock to build {normalized_name: (original_name, version)} mapping
         lock_content = secure_file_read(lock_path)
         try:
             import tomllib
         except ModuleNotFoundError:
             import tomli as tomllib  # Python < 3.11
         lock_data = tomllib.loads(lock_content)
-        locked_versions: dict[str, str] = {}
+        locked_packages: dict[str, tuple[str, str]] = {}
         for pkg in lock_data.get('package', []):
             source = pkg.get('source', {})
             # Only pin registry packages (from PyPI), skip editable/local/path
@@ -458,9 +462,9 @@ def pin_dependencies(directory: Path) -> int:
             name = pkg.get('name', '')
             version = pkg.get('version', '')
             if name and version:
-                locked_versions[_normalize_name(name)] = version
+                locked_packages[_normalize_name(name)] = (name, version)
 
-        logging.info(f'Loaded {len(locked_versions)} locked package versions from uv.lock')
+        logging.info(f'Loaded {len(locked_packages)} locked package versions from uv.lock')
 
         # Read and rewrite pyproject.toml
         pyproject_content = secure_file_read(pyproject_path)
@@ -469,26 +473,52 @@ def pin_dependencies(directory: Path) -> int:
         if not project_section:
             raise ValueError('No project section in pyproject.toml')
 
-        dependencies = project_section.get('dependencies')
-        if not dependencies:
-            click.echo('No dependencies found in pyproject.toml, nothing to pin')
-            return 0
+        # Get the project's own name so we don't add it as a dependency
+        project_name = project_section.get('name', '')
+        project_normalized = _normalize_name(str(project_name)) if project_name else ''
 
+        dependencies = project_section.get('dependencies')
+        if dependencies is None:
+            dependencies = tomlkit.array()
+            project_section['dependencies'] = dependencies
+
+        # Track which locked packages are already covered by direct deps
+        covered: set[str] = set()
         pinned_count = 0
+
+        # Phase 1: Pin existing direct dependencies to their locked versions
         for i, dep_str in enumerate(dependencies):
-            pinned = _pin_dependency(str(dep_str), locked_versions)
+            pkg_name = re.split(r'[><=!~\[;]', str(dep_str).strip())[0].strip()
+            normalized = _normalize_name(pkg_name)
+            covered.add(normalized)
+            pinned = _pin_dependency(str(dep_str), locked_packages)
             if pinned != str(dep_str):
                 dependencies[i] = pinned
                 pinned_count += 1
                 logging.info(f'Pinned: {dep_str} -> {pinned}')
 
-        if pinned_count == 0:
+        # Phase 2: Add all remaining transitive dependencies from uv.lock
+        added_count = 0
+        for normalized, (original_name, version) in sorted(locked_packages.items()):
+            if normalized in covered:
+                continue
+            if normalized == project_normalized:
+                continue
+            dep_entry = f'{original_name}=={version}'
+            dependencies.append(dep_entry)
+            added_count += 1
+            logging.info(f'Added transitive: {dep_entry}')
+
+        if pinned_count == 0 and added_count == 0:
             click.echo('All dependencies already pinned, no changes needed')
             return 0
 
         updated_content = tomlkit.dumps(data)
         secure_file_write(pyproject_path, updated_content)
-        click.echo(f'Pinned {pinned_count} dependencies in {pyproject_path}')
+        click.echo(
+            f'Pinned {pinned_count} direct + added {added_count} transitive '
+            f'dependencies in {pyproject_path}'
+        )
         return 0
 
     except Exception as e:
@@ -502,7 +532,7 @@ def _normalize_name(name: str) -> str:
     return re.sub(r'[-_.]+', '-', name).lower()
 
 
-def _pin_dependency(dep_str: str, locked_versions: dict[str, str]) -> str:
+def _pin_dependency(dep_str: str, locked_packages: dict[str, tuple[str, str]]) -> str:
     """Rewrite a dependency string to use == with the locked version.
 
     Handles dependency specifiers like:
@@ -532,11 +562,11 @@ def _pin_dependency(dep_str: str, locked_versions: dict[str, str]) -> str:
     pkg_name = re.split(r'[><=!~]', name_part.strip())[0].strip()
     normalized = _normalize_name(pkg_name)
 
-    if normalized not in locked_versions:
+    if normalized not in locked_packages:
         logging.warning(f'No locked version found for {pkg_name}, keeping as-is')
         return dep_str
 
-    locked_version = locked_versions[normalized]
+    _, locked_version = locked_packages[normalized]
     return f'{pkg_name}{extras}=={locked_version}{marker_part}'
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -312,6 +312,7 @@ jobs:
           sparse-checkout: |
             ${{ env.SRC_DIRECTORY }}/${{ matrix.changed-directory }}
             ./.github/actions/build-and-push-container-image
+            ./.github/workflows/release.py
       - name: Validate package directory
         run: |
           set -euo pipefail
@@ -351,11 +352,22 @@ jobs:
           echo "::debug::Directory validated: $FULL_PATH"
       - name: Install uv
         uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+      - name: Pin dependencies from lockfile
+        working-directory: ${{ env.SRC_DIRECTORY }}/${{ matrix.changed-directory }}
+        run: |
+          set -euo pipefail
+          echo "::debug::Pinning dependencies for package"
+          if [ -f "uv.lock" ]; then
+            uv run --script ../../.github/workflows/release.py pin-dependencies --directory="."
+            echo "::debug::Dependencies pinned from uv.lock"
+          else
+            echo "::debug::No uv.lock found, skipping dependency pinning"
+          fi
       - name: Build package
         working-directory: ${{ env.SRC_DIRECTORY }}/${{ matrix.changed-directory }}
         run: |
           set -euo pipefail
-          echo "::debug::Building package: ${{ matrix.changed-directory }}"
+          echo "::debug::Building package"
           uv build
           echo "::debug::Package build completed"
       - name: Get Version from Package


### PR DESCRIPTION
## Summary

When packages are published to PyPI via `uvx` (or `pip`), loose dependency specifiers like `>=1.40.5` allow the resolver to install the latest compatible version — which may differ significantly from what was tested. For example, a `uv.lock` may pin `boto3==1.42.62` during development, but `uvx awslabs.dynamodb-mcp-server@latest` installs `boto3==1.44.x` (or whatever is latest at the time).

This PR adds a **build-time dependency pinning step** to the release pipeline that rewrites `pyproject.toml` dependencies from loose (`>=`) to exact (`==`) version pins derived from the package's `uv.lock` file, before `uv build` creates the wheel.

### Changes

- **`.github/workflows/release.py`**: Added `pin-dependencies` command that:
  - Reads `uv.lock` to build a `{normalized_name: version}` map for all registry packages
  - Rewrites each dependency in `pyproject.toml` to use `==locked_version`
  - Preserves extras (e.g., `mcp[cli]>=1.23.0` → `mcp[cli]==1.26.0`)
  - Preserves environment markers
  - Skips editable/local/path packages
  - Uses PEP 503 name normalization for reliable matching

- **`.github/workflows/release.yml`**: Added `Pin dependencies from lockfile` step before `uv build` in the `publish-pypi` job. Also added `release.py` to the sparse-checkout so the script is available.

### Why not modify `uv`/`uvx` instead?

The `uv.lock` file does not travel with the published PyPI package — only `pyproject.toml` metadata (`Requires-Dist`) is included in the wheel. `uvx` has no lockfile to read. The `PreferenceLocation::Lock` infrastructure exists in `uv run` but requires a local lockfile, which defeats `uvx`'s zero-setup purpose. The correct fix is at the distribution level.

### Example transformations

| Before (development) | After (published wheel) |
|---|---|
| `boto3>=1.40.5` | `boto3==1.42.62` |
| `mcp[cli]>=1.23.0` | `mcp[cli]==1.26.0` |
| `typing-extensions>=4.14.1` | `typing-extensions==4.15.0` |
| `loguru==0.7.3` | `loguru==0.7.3` (unchanged) |

### Design decisions

- **Build-time only**: Pinning happens in CI before `uv build`, not in the git repo. Development keeps loose deps for flexibility.
- **Transitive deps too**: Not only are the dependencies listed in `pyproject.toml` are pinned, but also transitive deps are constrained by exact versions in the `uv.lock`.
- **Graceful degradation**: If no `uv.lock` exists, the step is skipped.

## Test plan

- [ ] Verify `pin-dependencies` command works: `uv run --script .github/workflows/release.py pin-dependencies --directory=src/dynamodb-mcp-server`
- [ ] Verify pinned `pyproject.toml` produces a valid wheel: `uv build` after pinning
- [ ] Verify `uvx` installs exact locked versions with the pinned wheel
- [ ] Test with a package that has no `uv.lock` (graceful skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)